### PR TITLE
标准化 'C main' 代码块

### DIFF
--- a/Release/ini/codeinsertion.ini
+++ b/Release/ini/codeinsertion.ini
@@ -4,7 +4,7 @@ Line=/*********************************************************************$_   
 Sep=0
 [C_main]
 Desc=C main
-Line=#include <stdio.h>$_$_int main() {$_	*|*$_$_	return 0;$_}$_
+Line=#include <stdio.h>$_$_int main(void) {$_	*|*$_$_	return 0;$_}$_
 Sep=0
 [C++_main]
 Desc=C++ main


### PR DESCRIPTION
C 语言中无参函数需要写上 `void` （与  C++ 不同）。
参考标准： ISO/IEC 9899:201x 5.1.2.2.1 